### PR TITLE
Add page-aligned and async io comparison

### DIFF
--- a/5_page_aligned.c
+++ b/5_page_aligned.c
@@ -1,0 +1,237 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <arm_neon.h>
+#include <dispatch/dispatch.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <string.h>
+
+#define PAGE_SIZE 8192
+
+typedef struct {
+    size_t total_words;
+    bool prev_ws;
+    uint8x16_t prev_ws_vec;
+    dispatch_queue_t process_queue;
+} shared_state_t;
+
+static inline bool is_ws_scalar(unsigned char c)
+{
+    switch (c)
+    {
+    case ' ':
+    case '\n':
+    case '\r':
+    case '\t':
+    case '\v':
+    case '\f':
+        return true;
+    default:
+        return false;
+    }
+}
+
+static size_t process_buffer_neon(const unsigned char *buffer, size_t len, uint8x16_t *prev_ws_vec, bool *prev_ws)
+{
+    size_t words = 0;
+    size_t i = 0;
+
+    if (len >= 16)
+    {
+        size_t nvec = len & ~(size_t)15;
+        for (; i < nvec; i += 16)
+        {
+            uint8x16_t bytes = vld1q_u8(buffer + i);
+
+            uint8x16_t ws1 = vceqq_u8(bytes, vdupq_n_u8(' '));
+            uint8x16_t ws2 = vceqq_u8(bytes, vdupq_n_u8('\n'));
+            uint8x16_t ws3 = vceqq_u8(bytes, vdupq_n_u8('\r'));
+            uint8x16_t ws4 = vceqq_u8(bytes, vdupq_n_u8('\t'));
+            uint8x16_t ws5 = vceqq_u8(bytes, vdupq_n_u8('\v'));
+            uint8x16_t ws6 = vceqq_u8(bytes, vdupq_n_u8('\f'));
+
+            uint8x16_t ws = vorrq_u8(ws1, ws2);
+            ws = vorrq_u8(ws, ws3);
+            ws = vorrq_u8(ws, ws4);
+            ws = vorrq_u8(ws, ws5);
+            ws = vorrq_u8(ws, ws6);
+
+            uint8x16_t prev_ws_shifted = vextq_u8(*prev_ws_vec, ws, 15);
+
+            uint8x16_t non_ws = vmvnq_u8(ws);
+            uint8x16_t start_mask = vandq_u8(non_ws, prev_ws_shifted);
+
+            uint8x16_t ones = vshrq_n_u8(start_mask, 7);
+
+            words += (size_t)vaddvq_u8(ones);
+
+            *prev_ws_vec = ws;
+        }
+
+        if (i > 0)
+        {
+            *prev_ws = is_ws_scalar(buffer[i - 1]);
+        }
+    }
+
+    for (; i < len; ++i)
+    {
+        unsigned char c = buffer[i];
+        bool cur_ws = is_ws_scalar(c);
+        if (!cur_ws && *prev_ws)
+        {
+            ++words;
+        }
+        *prev_ws = cur_ws;
+    }
+
+    return words;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        fprintf(stderr, "usage: wc <file>\n");
+        return 1;
+    }
+
+    // Open file with O_RDONLY for dispatch_io
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0)
+    {
+        perror("open");
+        return 1;
+    }
+
+    // Get file size for optimization
+    struct stat st;
+    if (fstat(fd, &st) < 0)
+    {
+        perror("fstat");
+        close(fd);
+        return 1;
+    }
+
+    if (st.st_size == 0)
+    {
+        close(fd);
+        printf("0\n");
+        return 0;
+    }
+
+    // Initialize state
+    shared_state_t *state = calloc(1, sizeof(shared_state_t));
+    if (!state)
+    {
+        perror("calloc");
+        close(fd);
+        return 1;
+    }
+    
+    state->prev_ws = true;
+    state->prev_ws_vec = vdupq_n_u8(0xFF);
+    
+    // Create a serial queue for processing to maintain order
+    state->process_queue = dispatch_queue_create("process.queue", DISPATCH_QUEUE_SERIAL);
+
+    // Create dispatch queue for I/O
+    dispatch_queue_t io_queue = dispatch_queue_create("io.queue", DISPATCH_QUEUE_CONCURRENT);
+    dispatch_group_t group = dispatch_group_create();
+
+    // Create dispatch I/O channel
+    dispatch_io_t channel = dispatch_io_create(DISPATCH_IO_STREAM, fd,
+                                                io_queue, ^(int error) {
+        if (error)
+        {
+            fprintf(stderr, "dispatch_io error: %d\n", error);
+        }
+        close(fd);
+    });
+
+    // Set the low water mark for reading
+    dispatch_io_set_low_water(channel, PAGE_SIZE);
+
+    // Read the entire file with dispatch_io_read
+    // Using off_t 0 and size_t SIZE_MAX to read the entire file
+    // dispatch_io will automatically chunk it into pages
+    dispatch_group_enter(group);
+    
+    dispatch_io_read(channel, 0, SIZE_MAX, io_queue,
+                     ^(bool done, dispatch_data_t data, int error) {
+        if (error)
+        {
+            fprintf(stderr, "Read error: %d\n", error);
+            if (done)
+            {
+                dispatch_group_leave(group);
+            }
+            return;
+        }
+
+        if (data && dispatch_data_get_size(data) > 0)
+        {
+            size_t data_size = dispatch_data_get_size(data);
+            
+            // Allocate buffer for this chunk
+            unsigned char *buffer = (unsigned char *)aligned_alloc(16, data_size);
+            if (!buffer)
+            {
+                fprintf(stderr, "Failed to allocate buffer\n");
+                if (done)
+                {
+                    dispatch_group_leave(group);
+                }
+                return;
+            }
+            
+            // Copy data to buffer
+            __block size_t copied = 0;
+            dispatch_data_apply(data, ^bool(__unused dispatch_data_t region,
+                                            __unused size_t offset_in_region,
+                                            const void *bytes,
+                                            size_t size) {
+                memcpy(buffer + copied, bytes, size);
+                copied += size;
+                return true;
+            });
+            
+            // Process this chunk on the serial processing queue
+            // This ensures chunks are processed in order
+            dispatch_async(state->process_queue, ^{
+                size_t words = process_buffer_neon(buffer, data_size, 
+                                                   &state->prev_ws_vec, 
+                                                   &state->prev_ws);
+                state->total_words += words;
+                free(buffer);
+            });
+        }
+
+        if (done)
+        {
+            dispatch_group_leave(group);
+        }
+    });
+
+    // Wait for all I/O and processing to complete
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    
+    // Ensure all processing is done
+    dispatch_sync(state->process_queue, ^{
+        // This block ensures all previous async processing is complete
+    });
+
+    // Cleanup
+    dispatch_io_close(channel, 0);
+    dispatch_release(channel);
+    dispatch_release(io_queue);
+    dispatch_release(state->process_queue);
+    dispatch_release(group);
+
+    printf("%zu\n", state->total_words);
+    
+    free(state);
+    return 0;
+}

--- a/bench.sh
+++ b/bench.sh
@@ -2,6 +2,7 @@
 clang -Wall -Wextra -Wpedantic -O3 -funroll-loops -march=native -o ./bin/2_mvp 2_mvp.c
 clang -Wall -Wextra -Wpedantic -O3 -funroll-loops -march=native -o ./bin/3_simd 3_simd.c
 clang -Wall -Wextra -Wpedantic -O3 -funroll-loops -march=native -pthread -o ./bin/4_threads 4_threads.c
+clang -Wall -Wextra -Wpedantic -O3 -funroll-loops -march=native -pthread -o ./bin/5_page_aligned 5_page_aligned.c
 
 # build benchmark gen
 clang -Wall -Wextra -Wpedantic -O3 -funroll-loops -march=native -o ./bin/setup_benchmark setup_benchmark.c
@@ -14,6 +15,7 @@ rm -f bench.txt
 ./bin/2_mvp bench.txt | grep -q 65076996 || echo "2_mvp failed" && exit 1
 ./bin/3_simd bench.txt | grep -q 65076996 || echo "3_simd failed" && exit 1
 ./bin/4_threads bench.txt | grep -q 65076996 || echo "4_threads failed" && exit 1
+./bin/5_page_aligned bench.txt | grep -q 65076996 || echo "5_page_aligned failed" && exit 1
 
 # run benchmark
 hyperfine --warmup 2 --min-runs 3 \
@@ -21,4 +23,5 @@ hyperfine --warmup 2 --min-runs 3 \
     'python3 1_c_regex.py bench.txt' \
     './bin/2_mvp bench.txt' \
     './bin/3_simd bench.txt' \
-    './bin/4_threads bench.txt'
+    './bin/4_threads bench.txt' \
+    './bin/5_page_aligned bench.txt'


### PR DESCRIPTION
I was able to get ~5% faster by using page-aligned IO reads and Grand Central Dispatch for async i/o operations.

```
% hyperfine --warmup 2 --min-runs 3 \
    './bin/2_mvp bench.txt' \
    './bin/3_simd bench.txt' \
    './bin/4_threads bench.txt' \
    './bin/5_page_aligned bench.txt'
Benchmark 1: ./bin/2_mvp bench.txt
  Time (mean ± σ):     829.5 ms ±   4.7 ms    [User: 729.0 ms, System: 97.6 ms]
  Range (min … max):   826.2 ms … 834.9 ms    3 runs
 
Benchmark 2: ./bin/3_simd bench.txt
  Time (mean ± σ):     152.7 ms ±   0.7 ms    [User: 54.9 ms, System: 95.3 ms]
  Range (min … max):   151.2 ms … 154.1 ms    19 runs
 
Benchmark 3: ./bin/4_threads bench.txt
  Time (mean ± σ):     110.2 ms ±   1.3 ms    [User: 82.9 ms, System: 95.8 ms]
  Range (min … max):   108.4 ms … 113.2 ms    26 runs
 
Benchmark 4: ./bin/5_page_aligned bench.txt
  Time (mean ± σ):     104.9 ms ±   0.8 ms    [User: 86.2 ms, System: 106.6 ms]
  Range (min … max):   103.4 ms … 106.7 ms    27 runs
 
Summary
  ./bin/5_page_aligned bench.txt ran
    1.05 ± 0.01 times faster than ./bin/4_threads bench.txt
    1.46 ± 0.01 times faster than ./bin/3_simd bench.txt
    7.91 ± 0.07 times faster than ./bin/2_mvp bench.txt
```